### PR TITLE
Configure Booking Made load test's throughput

### DIFF
--- a/src/gatling/kotlin/uk/gov/justice/digital/hmpps/team/cas/constants/Constants.ts.kt
+++ b/src/gatling/kotlin/uk/gov/justice/digital/hmpps/team/cas/constants/Constants.ts.kt
@@ -2,8 +2,9 @@ package uk.gov.justice.digital.hmpps.team.cas.constants
 
 import java.util.UUID
 
-const val noOfFastUsers = 6
-const val noOfSlowerUsers = 4
+const val noOfFastUsers = 8
+const val noOfAverageSpeedUsers = 4
+const val noOfSlowerUsers = 3
 
 const val fastBookingMadePauseOnCruDashboardPage = 4L
 const val fastBookingMadePauseOnPlacementRequestPage = 2L
@@ -12,12 +13,19 @@ const val fastBookingMadePauseOnOccupancyViewPage = 10L
 const val fastBookingMadePauseOnConfirmBookingPage = 3L
 const val fastBookingMadePauseOnConfirmBookingSubmitPage = 1L
 
-const val slowerBookingMadePauseOnCruDashboardPage = 8L
-const val slowerBookingMadePauseOnPlacementRequestPage = 4L
-const val slowerBookingMadePauseOnFindASpacePage = 8L
-const val slowerBookingMadePauseOnOccupancyViewPage = 20L
-const val slowerBookingMadePauseOnConfirmBookingPage = 6L
-const val slowerBookingMadePauseOnConfirmBookingSubmitPage = 2L
+const val averageSpeedBookingMadePauseOnCruDashboardPage = 8L
+const val averageSpeedBookingMadePauseOnPlacementRequestPage = 4L
+const val averageSpeedBookingMadePauseOnFindASpacePage = 8L
+const val averageSpeedBookingMadePauseOnOccupancyViewPage = 20L
+const val averageSpeedBookingMadePauseOnConfirmBookingPage = 6L
+const val averageSpeedBookingMadePauseOnConfirmBookingSubmitPage = 1L
+
+const val slowerBookingMadePauseOnCruDashboardPage = 16L
+const val slowerBookingMadePauseOnPlacementRequestPage = 8L
+const val slowerBookingMadePauseOnFindASpacePage = 16L
+const val slowerBookingMadePauseOnOccupancyViewPage = 40L
+const val slowerBookingMadePauseOnConfirmBookingPage = 12L
+const val slowerBookingMadePauseOnConfirmBookingSubmitPage = 1L
 
 // values for JDBC feed where clause
 const val cruDashboardNotMatchedStatus = "notMatched"

--- a/src/gatling/kotlin/uk/gov/justice/digital/hmpps/team/cas/service/BookingMadeScenarioService.kt
+++ b/src/gatling/kotlin/uk/gov/justice/digital/hmpps/team/cas/service/BookingMadeScenarioService.kt
@@ -5,7 +5,7 @@ import io.gatling.javaapi.core.ScenarioBuilder
 import io.gatling.javaapi.http.HttpDsl
 import uk.gov.justice.digital.hmpps.helper.HttpRequestHelper
 import uk.gov.justice.digital.hmpps.team.cas.jdbc.CruDashboardFeeder
-import java.util.*
+import java.util.UUID
 
 class BookingMadeScenarioService(
     private val cruDashboardFeeder: CruDashboardFeeder = CruDashboardFeeder(),

--- a/src/gatling/kotlin/uk/gov/justice/digital/hmpps/team/cas/simulations/BookingMadeSimulation.kt
+++ b/src/gatling/kotlin/uk/gov/justice/digital/hmpps/team/cas/simulations/BookingMadeSimulation.kt
@@ -5,7 +5,7 @@ import uk.gov.justice.digital.hmpps.BaseSimulationFrontEndRoutes
 import uk.gov.justice.digital.hmpps.team.cas.constants.*
 import uk.gov.justice.digital.hmpps.team.cas.service.BookingMadeScenarioService
 import kotlin.time.*
-import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Duration.Companion.minutes
 
 const val dev_profile: String = "dev"
 const val test_profile: String = "test"
@@ -18,7 +18,7 @@ class BookingMadeSimulation(bookingMadeScenarioService: BookingMadeScenarioServi
 
         val fastBookingMadeScenario =
             bookingMadeScenarioService.buildBookingMadeScenario(
-                scenarioName = "Booking Made Scenario - Fast Users",
+                scenarioName = "Booking Made Scenario - Fast users",
                 cruDashboardNotMatchedStatus,
                 cruManagementAreaId,
                 fastBookingMadePauseOnCruDashboardPage,
@@ -29,9 +29,22 @@ class BookingMadeSimulation(bookingMadeScenarioService: BookingMadeScenarioServi
                 fastBookingMadePauseOnConfirmBookingSubmitPage
             )
 
+        val averageSpeedBookingMadeScenario =
+            bookingMadeScenarioService.buildBookingMadeScenario(
+                scenarioName = "Booking Made Scenario - Average speed users",
+                cruDashboardNotMatchedStatus,
+                cruManagementAreaId,
+                averageSpeedBookingMadePauseOnCruDashboardPage,
+                averageSpeedBookingMadePauseOnPlacementRequestPage,
+                averageSpeedBookingMadePauseOnFindASpacePage,
+                averageSpeedBookingMadePauseOnOccupancyViewPage,
+                averageSpeedBookingMadePauseOnConfirmBookingPage,
+                averageSpeedBookingMadePauseOnConfirmBookingSubmitPage
+            )
+
         val slowerBookingMadeScenario =
             bookingMadeScenarioService.buildBookingMadeScenario(
-                scenarioName = "Booking Made Scenario - Slower Users",
+                scenarioName = "Booking Made Scenario - Slower users",
                 cruDashboardNotMatchedStatus,
                 cruManagementAreaId,
                 slowerBookingMadePauseOnCruDashboardPage,
@@ -43,12 +56,15 @@ class BookingMadeSimulation(bookingMadeScenarioService: BookingMadeScenarioServi
             )
         setUp(
             fastBookingMadeScenario.injectClosed(
-                constantConcurrentUsers(noOfFastUsers).during(20.seconds.toJavaDuration())
+                constantConcurrentUsers(noOfFastUsers).during(20.minutes.toJavaDuration())
+            ),
+            averageSpeedBookingMadeScenario.injectClosed(
+                constantConcurrentUsers(noOfAverageSpeedUsers).during(20.minutes.toJavaDuration())
             ),
             slowerBookingMadeScenario.injectClosed(
-                constantConcurrentUsers(noOfSlowerUsers).during(20.seconds.toJavaDuration())
+                constantConcurrentUsers(noOfSlowerUsers).during(20.minutes.toJavaDuration())
             ),
         ).protocols(httpProtocol)
-            .maxDuration(20.seconds.toJavaDuration())
+            .maxDuration(20.minutes.toJavaDuration())
     }
 }


### PR DESCRIPTION
**PR includes:**
* Configuring the `Booking Made` load test's throughput
* I also split the load out between 3 users groups to guarantee distributed traffic during the load test (previously it had only two user groups)

**Rationale for numbers**
* In production there are `32 staff members`, across all APs, who can do this `Booking Made` journey
* Therefore, we are setting the `number of concurrent users` to `15` as it’s very unlikely they will all be online simultaneously and doing the same user journey
* This is way beyond what we need for private beta (as this will be limited to South West South Central)
* We also wanted to run for a pro-longed period, so we will run it for 20mins (as this just about qualifies as a soak test). 